### PR TITLE
G-32 | Adds consent-request/on-init API & tests for it.

### DIFF
--- a/src/main/java/in/projecteka/gateway/GatewayConfiguration.java
+++ b/src/main/java/in/projecteka/gateway/GatewayConfiguration.java
@@ -115,8 +115,9 @@ public class GatewayConfiguration {
 
     @Bean("discoveryResponseAction")
     public DefaultValidatedResponseAction<DiscoveryServiceClient> discoveryResponseAction(DiscoveryServiceClient discoveryServiceClient,
-                                                                                          CMRegistry cmRegistry) {
-        return new DefaultValidatedResponseAction<>(discoveryServiceClient, cmRegistry);
+                                                                                          CMRegistry cmRegistry,
+                                                                                          BridgeRegistry bridgeRegistry) {
+        return new DefaultValidatedResponseAction<>(discoveryServiceClient, cmRegistry, bridgeRegistry);
     }
 
     @Bean("discoveryResponseOrchestrator")
@@ -150,8 +151,9 @@ public class GatewayConfiguration {
 
     @Bean("linkInitResponseAction")
     public DefaultValidatedResponseAction<LinkInitServiceClient> linkInitResponseAction(LinkInitServiceClient linkInitServiceClient,
-                                                                                        CMRegistry cmRegistry) {
-        return new DefaultValidatedResponseAction<>(linkInitServiceClient, cmRegistry);
+                                                                                        CMRegistry cmRegistry,
+                                                                                        BridgeRegistry bridgeRegistry) {
+        return new DefaultValidatedResponseAction<>(linkInitServiceClient, cmRegistry, bridgeRegistry);
     }
 
     @Bean("linkInitResponseOrchestrator")
@@ -178,8 +180,9 @@ public class GatewayConfiguration {
 
     @Bean("linkConfirmResponseAction")
     public DefaultValidatedResponseAction<LinkConfirmServiceClient> linkConfirmResponseAction(LinkConfirmServiceClient linkConfirmServiceClient,
-                                                                                              CMRegistry cmRegistry) {
-        return new DefaultValidatedResponseAction<>(linkConfirmServiceClient, cmRegistry);
+                                                                                              CMRegistry cmRegistry,
+                                                                                              BridgeRegistry bridgeRegistry) {
+        return new DefaultValidatedResponseAction<>(linkConfirmServiceClient, cmRegistry, bridgeRegistry);
     }
 
     @Bean
@@ -252,4 +255,18 @@ public class GatewayConfiguration {
                                            ClientRegistryClient clientRegistryClient) {
         return new CentralRegistry(clientRegistryClient, clientRegistryProperties);
     }
+
+    @Bean("consentResponseAction")
+    public DefaultValidatedResponseAction<ConsentRequestServiceClient> consentResponseAction(ConsentRequestServiceClient consentRequestServiceClient,
+                                                                                             CMRegistry cmRegistry,
+                                                                                             BridgeRegistry bridgeRegistry) {
+        return new DefaultValidatedResponseAction<>(consentRequestServiceClient, cmRegistry, bridgeRegistry);
+    }
+
+    @Bean("consentResponseOrchestrator")
+    public ResponseOrchestrator consentResponseOrchestrator(Validator validator,
+                                                              DefaultValidatedResponseAction<ConsentRequestServiceClient> consentResponseAction) {
+        return new ResponseOrchestrator(validator, consentResponseAction);
+    }
+
 }

--- a/src/main/java/in/projecteka/gateway/clients/ConsentRequestServiceClient.java
+++ b/src/main/java/in/projecteka/gateway/clients/ConsentRequestServiceClient.java
@@ -83,7 +83,8 @@ public class ConsentRequestServiceClient implements ServiceClient {
                                         .retrieve()
                                         .onStatus(httpStatus -> !httpStatus.is2xxSuccessful(),
                                                 clientResponse -> Mono.error(ClientError.unableToConnect()))//TODO Error handling
-                                        .bodyToMono(Void.class)
-                                        .timeout(Duration.ofSeconds(serviceOptions.getTimeout()))));
+                                        .toBodilessEntity()
+                                        .timeout(Duration.ofSeconds(serviceOptions.getTimeout()))))
+                                        .then();
     }
 }

--- a/src/main/java/in/projecteka/gateway/clients/ServiceClient.java
+++ b/src/main/java/in/projecteka/gateway/clients/ServiceClient.java
@@ -11,5 +11,5 @@ public interface ServiceClient {
 
     Mono<Void> notifyError(ErrorResult request);
 
-    Mono<Void> routeResponse(JsonNode request, String cmUrl);
+    Mono<Void> routeResponse(JsonNode request, String url);
 }

--- a/src/main/java/in/projecteka/gateway/common/Constants.java
+++ b/src/main/java/in/projecteka/gateway/common/Constants.java
@@ -3,6 +3,7 @@ package in.projecteka.gateway.common;
 public class Constants {
     public static final String X_HIP_ID = "X-HIP-ID";
     public static final String X_CM_ID = "X-CM-ID";
+    public static final String X_HIU_ID = "X-HIU-ID";
     public static final String TEMP_CM_ID = "ncg";//TODO
     public static final String TEMP_HIU_ID = "10000005";//TODO
     public static final String REQUEST_ID = "requestId";

--- a/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
@@ -23,8 +23,8 @@ public class DefaultValidatedResponseAction<T extends ServiceClient> implements 
     BridgeRegistry bridgeRegistry;
 
     @Override
-    public Mono<Void> routeResponse(String id, JsonNode updatedRequest) {
-        Optional<YamlRegistryMapping> configFor = id.equals(X_HIU_ID)
+    public Mono<Void> routeResponse(String x_id, String id, JsonNode updatedRequest) {
+        Optional<YamlRegistryMapping> configFor = x_id.equals(X_HIU_ID)
                 ? bridgeRegistry.getConfigFor(id, ServiceType.HIU)
                 : cmRegistry.getConfigFor(id);
         if (configFor.isEmpty()) {

--- a/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
@@ -28,7 +28,7 @@ public class DefaultValidatedResponseAction<T extends ServiceClient> implements 
                 ? bridgeRegistry.getConfigFor(id, ServiceType.HIU)
                 : cmRegistry.getConfigFor(id);
         if (configFor.isEmpty()) {
-            logger.error("No mapping found for {}",id);
+            logger.error("No mapping found for {}", id);
             return Mono.empty();
         }
         return serviceClient.routeResponse(updatedRequest,configFor.get().getHost());

--- a/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/DefaultValidatedResponseAction.java
@@ -2,7 +2,9 @@ package in.projecteka.gateway.common;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import in.projecteka.gateway.clients.ServiceClient;
+import in.projecteka.gateway.registry.BridgeRegistry;
 import in.projecteka.gateway.registry.CMRegistry;
+import in.projecteka.gateway.registry.ServiceType;
 import in.projecteka.gateway.registry.YamlRegistryMapping;
 import lombok.AllArgsConstructor;
 import org.slf4j.Logger;
@@ -11,26 +13,31 @@ import reactor.core.publisher.Mono;
 
 import java.util.Optional;
 
+import static in.projecteka.gateway.common.Constants.X_HIU_ID;
+
 @AllArgsConstructor
 public class DefaultValidatedResponseAction<T extends ServiceClient> implements ValidatedResponseAction{
     private static final Logger logger = LoggerFactory.getLogger(DefaultValidatedResponseAction.class);
     T serviceClient;
     CMRegistry cmRegistry;
+    BridgeRegistry bridgeRegistry;
 
     @Override
-    public Mono<Void> routeResponse(String xCmId, JsonNode updatedRequest) {
-        Optional<YamlRegistryMapping> configFor = cmRegistry.getConfigFor(xCmId);
+    public Mono<Void> routeResponse(String id, JsonNode updatedRequest) {
+        Optional<YamlRegistryMapping> configFor = id.equals(X_HIU_ID)
+                ? bridgeRegistry.getConfigFor(id, ServiceType.HIU)
+                : cmRegistry.getConfigFor(id);
         if (configFor.isEmpty()) {
-            logger.error("No mapping found for {}",xCmId);
+            logger.error("No mapping found for {}",id);
             return Mono.empty();
         }
         return serviceClient.routeResponse(updatedRequest,configFor.get().getHost());
     }
 
     @Override
-    public Mono<Void> handleError(Throwable throwable, String xCmId, JsonNode jsonNode) {
+    public Mono<Void> handleError(Throwable throwable, String id, JsonNode jsonNode) {
         //Does it make sense to call the same API back to notify only Error?
-        logger.error("Error in notifying CM with result",throwable);
+        logger.error("Error in notifying host with result",throwable);
         return Mono.empty();
     }
 }

--- a/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
+++ b/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
@@ -14,12 +14,12 @@ public class ResponseOrchestrator {
 
     private static final Logger logger = LoggerFactory.getLogger(ResponseOrchestrator.class);
     public Mono<Void> processResponse(HttpEntity<String> requestEntity, String id) {
-        return validator.validateResponse(requestEntity, id)
+        validator.validateResponse(requestEntity, id)
                 .flatMap(validRequest -> {
                     JsonNode updatedJsonNode = Utils.updateRequestId(validRequest.getDeserializedJsonNode(),
                             validRequest.getCallerRequestId());
-                    validatedResponseAction.execute(validRequest.getId(), updatedJsonNode).subscribe();
-                    return Mono.empty();
-                });
+                    return validatedResponseAction.execute(validRequest.getId(), updatedJsonNode);
+                }).subscribe();
+        return Mono.empty();
     }
 }

--- a/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
+++ b/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
@@ -18,7 +18,8 @@ public class ResponseOrchestrator {
                 .flatMap(validRequest -> {
                     JsonNode updatedJsonNode = Utils.updateRequestId(validRequest.getDeserializedJsonNode(),
                             validRequest.getCallerRequestId());
-                    return validatedResponseAction.execute(validRequest.getId(),updatedJsonNode);
+                    validatedResponseAction.execute(validRequest.getId(), updatedJsonNode).subscribe();
+                    return Mono.empty();
                 });
     }
 }

--- a/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
+++ b/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
@@ -10,16 +10,15 @@ import reactor.core.publisher.Mono;
 @AllArgsConstructor
 public class ResponseOrchestrator {
     Validator validator;
-
     ValidatedResponseAction validatedResponseAction;
 
     private static final Logger logger = LoggerFactory.getLogger(ResponseOrchestrator.class);
-    public Mono<Void> processResponse(HttpEntity<String> requestEntity) {
-        return validator.validateResponse(requestEntity)
+    public Mono<Void> processResponse(HttpEntity<String> requestEntity, String id) {
+        return validator.validateResponse(requestEntity, id)
                 .flatMap(validRequest -> {
                     JsonNode updatedJsonNode = Utils.updateRequestId(validRequest.getDeserializedJsonNode(),
                             validRequest.getCallerRequestId());
-                    return validatedResponseAction.execute(validRequest.getXCmId(),updatedJsonNode);
+                    return validatedResponseAction.execute(validRequest.getId(),updatedJsonNode);
                 });
     }
 }

--- a/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
+++ b/src/main/java/in/projecteka/gateway/common/ResponseOrchestrator.java
@@ -18,7 +18,7 @@ public class ResponseOrchestrator {
                 .flatMap(validRequest -> {
                     JsonNode updatedJsonNode = Utils.updateRequestId(validRequest.getDeserializedJsonNode(),
                             validRequest.getCallerRequestId());
-                    return validatedResponseAction.execute(validRequest.getId(), updatedJsonNode);
+                    return validatedResponseAction.execute(id, validRequest.getId(), updatedJsonNode);
                 }).subscribe();
         return Mono.empty();
     }

--- a/src/main/java/in/projecteka/gateway/common/RetryableValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/RetryableValidatedResponseAction.java
@@ -18,6 +18,7 @@ import java.util.List;
 import java.util.Map;
 
 import static in.projecteka.gateway.common.Constants.GW_DEAD_LETTER_EXCHANGE;
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
 
 public class RetryableValidatedResponseAction<T extends ServiceClient> implements MessageListener,ValidatedResponseAction {
     private static final Logger logger = LoggerFactory.getLogger(RetryableValidatedResponseAction.class);
@@ -40,7 +41,7 @@ public class RetryableValidatedResponseAction<T extends ServiceClient> implement
         JsonNode jsonNode = (JsonNode) converter.fromMessage(message, ParameterizedTypeReference.forType(JsonNode.class));
         String xCmId = message.getMessageProperties().getHeader("X-CM-ID");
         try {
-            routeResponse(xCmId, jsonNode).block();
+            routeResponse(X_CM_ID, xCmId, jsonNode).block();
         } catch (Exception e) {
             if (hasExceededRetryCount(message)) {
                 logger.error("Exceeded retry attempts; parking the message");
@@ -64,8 +65,8 @@ public class RetryableValidatedResponseAction<T extends ServiceClient> implement
     }
 
     @Override
-    public Mono<Void> routeResponse(String xCmId, JsonNode updatedRequest) {
-        return defaultValidatedResponseAction.routeResponse(xCmId,updatedRequest);
+    public Mono<Void> routeResponse(String x_id, String xCmId, JsonNode updatedRequest) {
+        return defaultValidatedResponseAction.routeResponse(x_id, xCmId,updatedRequest);
     }
 
     @Override

--- a/src/main/java/in/projecteka/gateway/common/ValidatedResponse.java
+++ b/src/main/java/in/projecteka/gateway/common/ValidatedResponse.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 @Getter
 @AllArgsConstructor
 public class ValidatedResponse {
-    String xCmId;
+    String id;
     String callerRequestId;
     JsonNode deserializedJsonNode;
 }

--- a/src/main/java/in/projecteka/gateway/common/ValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/ValidatedResponseAction.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import reactor.core.publisher.Mono;
 
 public interface ValidatedResponseAction {
-    default Mono<Void> execute(String xCmId, JsonNode updatedRequest) {
-        return routeResponse(xCmId, updatedRequest)
-                .onErrorResume(throwable -> handleError(throwable, xCmId,updatedRequest));
+    default Mono<Void> execute(String id, JsonNode updatedRequest) {
+        return routeResponse(id, updatedRequest)
+                .onErrorResume(throwable -> handleError(throwable, id, updatedRequest));
     }
 
-    Mono<Void> routeResponse(String xCmId, JsonNode updatedRequest);
+    Mono<Void> routeResponse(String id, JsonNode updatedRequest);
 
-    Mono<Void> handleError(Throwable throwable, String xCmId, JsonNode jsonNode);
+    Mono<Void> handleError(Throwable throwable, String id, JsonNode jsonNode);
 }

--- a/src/main/java/in/projecteka/gateway/common/ValidatedResponseAction.java
+++ b/src/main/java/in/projecteka/gateway/common/ValidatedResponseAction.java
@@ -4,12 +4,12 @@ import com.fasterxml.jackson.databind.JsonNode;
 import reactor.core.publisher.Mono;
 
 public interface ValidatedResponseAction {
-    default Mono<Void> execute(String id, JsonNode updatedRequest) {
-        return routeResponse(id, updatedRequest)
+    default Mono<Void> execute(String x_id, String id, JsonNode updatedRequest) {
+        return routeResponse(x_id, id, updatedRequest)
                 .onErrorResume(throwable -> handleError(throwable, id, updatedRequest));
     }
 
-    Mono<Void> routeResponse(String id, JsonNode updatedRequest);
+    Mono<Void> routeResponse(String x_id, String id, JsonNode updatedRequest);
 
     Mono<Void> handleError(Throwable throwable, String id, JsonNode jsonNode);
 }

--- a/src/main/java/in/projecteka/gateway/consent/ConsentController.java
+++ b/src/main/java/in/projecteka/gateway/consent/ConsentController.java
@@ -3,6 +3,7 @@ package in.projecteka.gateway.consent;
 import in.projecteka.gateway.clients.ConsentFetchServiceClient;
 import in.projecteka.gateway.clients.ConsentRequestServiceClient;
 import in.projecteka.gateway.common.RequestOrchestrator;
+import in.projecteka.gateway.common.ResponseOrchestrator;
 import lombok.AllArgsConstructor;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpStatus;
@@ -11,12 +12,14 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+import static in.projecteka.gateway.common.Constants.X_HIU_ID;
 import static in.projecteka.gateway.common.Constants.X_CM_ID;
 
 @RestController
 @AllArgsConstructor
 public class ConsentController {
     RequestOrchestrator<ConsentRequestServiceClient> consentRequestOrchestrator;
+    ResponseOrchestrator consentResponseOrchestrator;
     RequestOrchestrator<ConsentFetchServiceClient> consentFetchOrchestrator;
 
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -28,16 +31,18 @@ public class ConsentController {
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)
-    @PostMapping("/v1/consents/fetch")
-    public Mono<Void> fetchConsent(HttpEntity<String> requestEntity) {
-        Mono<Void> toBeFiredAndForgotten = consentFetchOrchestrator.processRequest(requestEntity, X_CM_ID);
+    @PostMapping("/v1/consent-requests/on-init")
+    public Mono<Void> onDiscoverCareContext(HttpEntity<String> requestEntity) {
+        Mono<Void> toBeFiredAndForgotten = consentResponseOrchestrator.processResponse(requestEntity, X_HIU_ID);
         toBeFiredAndForgotten.subscribe();
         return Mono.empty();
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)
-    @PostMapping("/v1/consent-requests/on-init")
-    public Mono<Void> onDiscoverCareContext(HttpEntity<String> requestEntity) {
+    @PostMapping("/v1/consents/fetch")
+    public Mono<Void> fetchConsent(HttpEntity<String> requestEntity) {
+        Mono<Void> toBeFiredAndForgotten = consentFetchOrchestrator.processRequest(requestEntity, X_CM_ID);
+        toBeFiredAndForgotten.subscribe();
         return Mono.empty();
     }
 }

--- a/src/main/java/in/projecteka/gateway/consent/ConsentController.java
+++ b/src/main/java/in/projecteka/gateway/consent/ConsentController.java
@@ -33,9 +33,7 @@ public class ConsentController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/consent-requests/on-init")
     public Mono<Void> onDiscoverCareContext(HttpEntity<String> requestEntity) {
-        Mono<Void> toBeFiredAndForgotten = consentResponseOrchestrator.processResponse(requestEntity, X_HIU_ID);
-        toBeFiredAndForgotten.subscribe();
-        return Mono.empty();
+        return consentResponseOrchestrator.processResponse(requestEntity, X_HIU_ID);
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)

--- a/src/main/java/in/projecteka/gateway/link/discovery/DiscoveryController.java
+++ b/src/main/java/in/projecteka/gateway/link/discovery/DiscoveryController.java
@@ -31,8 +31,6 @@ public class DiscoveryController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/care-contexts/on-discover")
     public Mono<Void> onDiscoverCareContext(HttpEntity<String> requestEntity) {
-        Mono<Void> tobeFiredAndForgotten = discoveryResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
-        tobeFiredAndForgotten.subscribe();
-        return Mono.empty();
+        return discoveryResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
     }
 }

--- a/src/main/java/in/projecteka/gateway/link/discovery/DiscoveryController.java
+++ b/src/main/java/in/projecteka/gateway/link/discovery/DiscoveryController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static in.projecteka.gateway.common.Constants.X_HIP_ID;
 
 @RestController
@@ -30,7 +31,7 @@ public class DiscoveryController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/care-contexts/on-discover")
     public Mono<Void> onDiscoverCareContext(HttpEntity<String> requestEntity) {
-        Mono<Void> tobeFiredAndForgotten = discoveryResponseOrchestrator.processResponse(requestEntity);
+        Mono<Void> tobeFiredAndForgotten = discoveryResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
         tobeFiredAndForgotten.subscribe();
         return Mono.empty();
     }

--- a/src/main/java/in/projecteka/gateway/link/link/LinkController.java
+++ b/src/main/java/in/projecteka/gateway/link/link/LinkController.java
@@ -34,9 +34,7 @@ public class LinkController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/links/link/on-init")
     public Mono<Void> linkOnInit(HttpEntity<String> requestEntity) {
-        Mono<Void> toBeFiredAndForgotten = linkInitResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
-        toBeFiredAndForgotten.subscribe();
-        return Mono.empty();
+        return linkInitResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
     }
 
     @ResponseStatus(HttpStatus.ACCEPTED)
@@ -50,8 +48,6 @@ public class LinkController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/links/link/on-confirm")
     public Mono<Void> linkOnConfirm(HttpEntity<String> requestEntity) {
-        Mono<Void> tobeFiredAndForgotten = linkConfirmResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
-        tobeFiredAndForgotten.subscribe();
-        return Mono.empty();
+        return linkConfirmResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
     }
 }

--- a/src/main/java/in/projecteka/gateway/link/link/LinkController.java
+++ b/src/main/java/in/projecteka/gateway/link/link/LinkController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import reactor.core.publisher.Mono;
 
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static in.projecteka.gateway.common.Constants.X_HIP_ID;
 
 @RestController
@@ -33,7 +34,7 @@ public class LinkController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/links/link/on-init")
     public Mono<Void> linkOnInit(HttpEntity<String> requestEntity) {
-        Mono<Void> toBeFiredAndForgotten = linkInitResponseOrchestrator.processResponse(requestEntity);
+        Mono<Void> toBeFiredAndForgotten = linkInitResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
         toBeFiredAndForgotten.subscribe();
         return Mono.empty();
     }
@@ -49,7 +50,7 @@ public class LinkController {
     @ResponseStatus(HttpStatus.ACCEPTED)
     @PostMapping("/v1/links/link/on-confirm")
     public Mono<Void> linkOnConfirm(HttpEntity<String> requestEntity) {
-        Mono<Void> tobeFiredAndForgotten = linkConfirmResponseOrchestrator.processResponse(requestEntity);
+        Mono<Void> tobeFiredAndForgotten = linkConfirmResponseOrchestrator.processResponse(requestEntity, X_CM_ID);
         tobeFiredAndForgotten.subscribe();
         return Mono.empty();
     }

--- a/src/test/java/in/projecteka/gateway/common/DefaultValidatedResponseActionTest.java
+++ b/src/test/java/in/projecteka/gateway/common/DefaultValidatedResponseActionTest.java
@@ -15,6 +15,7 @@ import reactor.test.StepVerifier;
 
 import java.util.Optional;
 
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -38,7 +39,7 @@ class DefaultValidatedResponseActionTest {
         String cmId  = "testCMId";
         when(cmRegistry.getConfigFor(cmId)).thenReturn(Optional.empty());
 
-        StepVerifier.create(defaultValidatedResponseAction.routeResponse(cmId,null))
+        StepVerifier.create(defaultValidatedResponseAction.routeResponse(X_CM_ID, cmId,null))
                 .verifyComplete();
     }
 
@@ -51,7 +52,7 @@ class DefaultValidatedResponseActionTest {
         JsonNode mockRequest = Mockito.mock(JsonNode.class);
         when(serviceClient.routeResponse(mockRequest,testHost)).thenReturn(Mono.empty());
 
-        StepVerifier.create(defaultValidatedResponseAction.routeResponse(cmId,mockRequest))
+        StepVerifier.create(defaultValidatedResponseAction.routeResponse(X_CM_ID, cmId, mockRequest))
                 .verifyComplete();
         verify(serviceClient).routeResponse(mockRequest,testHost);
     }

--- a/src/test/java/in/projecteka/gateway/common/ResponseOrchestratorTest.java
+++ b/src/test/java/in/projecteka/gateway/common/ResponseOrchestratorTest.java
@@ -20,6 +20,8 @@ import reactor.test.StepVerifier;
 
 import java.util.UUID;
 
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
+import static in.projecteka.gateway.common.Constants.X_HIU_ID;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -43,9 +45,9 @@ class ResponseOrchestratorTest {
     @Test
     public void shouldNotCallCMonValidationErrors() {
         HttpEntity<String> requestEntity = new HttpEntity<>("");
-        when(discoveryValidator.validateResponse(requestEntity)).thenReturn(Mono.empty());
+        when(discoveryValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.empty());
 
-        StepVerifier.create(responseOrchestrator.processResponse(requestEntity))
+        StepVerifier.create(responseOrchestrator.processResponse(requestEntity, X_CM_ID))
                 .verifyComplete();
     }
     @Test
@@ -59,16 +61,15 @@ class ResponseOrchestratorTest {
         objectNode.set("resp",respNode);
         HttpEntity<String> requestEntity = new HttpEntity<>(new ObjectMapper().writeValueAsString(objectNode));
 
-        String testhost = "testhost";
         String testCmId = "testCmId";
-        when(discoveryValidator.validateResponse(requestEntity)).thenReturn(Mono.just(new ValidatedResponse(testCmId,cmRequestId, objectNode)));
+        when(discoveryValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testCmId,cmRequestId, objectNode)));
         when(requestIdMappings.get(eq(requestId))).thenReturn(Mono.just(cmRequestId));
         when(validatedResponseAction.execute(eq(testCmId),jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
-        StepVerifier.create(responseOrchestrator.processResponse(requestEntity))
+        StepVerifier.create(responseOrchestrator.processResponse(requestEntity, X_CM_ID))
                 .verifyComplete();
 
-        verify(discoveryValidator).validateResponse(requestEntity);
+        verify(discoveryValidator).validateResponse(requestEntity, X_CM_ID);
         Assertions.assertEquals(cmRequestId,jsonNodeArgumentCaptor.getValue().path("resp").path("requestId").asText());
     }
 

--- a/src/test/java/in/projecteka/gateway/common/ResponseOrchestratorTest.java
+++ b/src/test/java/in/projecteka/gateway/common/ResponseOrchestratorTest.java
@@ -64,7 +64,7 @@ class ResponseOrchestratorTest {
         String testCmId = "testCmId";
         when(discoveryValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testCmId,cmRequestId, objectNode)));
         when(requestIdMappings.get(eq(requestId))).thenReturn(Mono.just(cmRequestId));
-        when(validatedResponseAction.execute(eq(testCmId),jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
+        when(validatedResponseAction.execute(eq(X_CM_ID), eq(testCmId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         StepVerifier.create(responseOrchestrator.processResponse(requestEntity, X_CM_ID))
                 .verifyComplete();

--- a/src/test/java/in/projecteka/gateway/common/RetryableValidatedResponseActionTest.java
+++ b/src/test/java/in/projecteka/gateway/common/RetryableValidatedResponseActionTest.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
 import static org.mockito.Mockito.doNothing;
@@ -64,11 +65,11 @@ class RetryableValidatedResponseActionTest {
         props.setHeader("X-CM-ID", testCmId);
         when(converter.fromMessage(message, ParameterizedTypeReference.forType(JsonNode.class))).thenReturn(jsonNode);
         when(message.getMessageProperties().getHeader("X-CM-ID")).thenReturn(testCmId);
-        doReturn(Mono.empty()).when(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        doReturn(Mono.empty()).when(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
 
         retryableValidatedResponseAction.onMessage(message);
 
-        verify(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        verify(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
     }
 
     @Test
@@ -79,11 +80,11 @@ class RetryableValidatedResponseActionTest {
         when(converter.fromMessage(message, ParameterizedTypeReference.forType(JsonNode.class))).thenReturn(jsonNode);
         when(message.getMessageProperties().getHeader("X-CM-ID")).thenReturn(testCmId);
         doReturn(false).when(retryableValidatedResponseAction).hasExceededRetryCount(message);
-        doReturn(Mono.error(new RuntimeException())).when(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        doReturn(Mono.error(new RuntimeException())).when(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
 
         Assertions.assertThrows(AmqpRejectAndDontRequeueException.class,() -> retryableValidatedResponseAction.onMessage(message));
 
-        verify(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        verify(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
         verify(retryableValidatedResponseAction).hasExceededRetryCount(message);
     }
 
@@ -98,11 +99,11 @@ class RetryableValidatedResponseActionTest {
         when(message.getMessageProperties().getReceivedRoutingKey()).thenReturn(testRoutingKey);
         doNothing().when(amqpTemplate).convertAndSend("gw.parking.exchange",testRoutingKey,message);
         doReturn(true).when(retryableValidatedResponseAction).hasExceededRetryCount(message);
-        doReturn(Mono.error(new RuntimeException())).when(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        doReturn(Mono.error(new RuntimeException())).when(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
 
         retryableValidatedResponseAction.onMessage(message);
 
-        verify(retryableValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        verify(retryableValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
         verify(retryableValidatedResponseAction).hasExceededRetryCount(message);
         verify(amqpTemplate).convertAndSend("gw.parking.exchange",testRoutingKey,message);
     }
@@ -134,11 +135,11 @@ class RetryableValidatedResponseActionTest {
     @Test
     void shouldRouteResponse() {
         String testCmId = "testCmId";
-        when(defaultValidatedResponseAction.routeResponse(testCmId,jsonNode)).thenReturn(Mono.empty());
+        when(defaultValidatedResponseAction.routeResponse(X_CM_ID, testCmId,jsonNode)).thenReturn(Mono.empty());
 
-        StepVerifier.create(retryableValidatedResponseAction.routeResponse(testCmId,jsonNode)).verifyComplete();
+        StepVerifier.create(retryableValidatedResponseAction.routeResponse(X_CM_ID, testCmId,jsonNode)).verifyComplete();
 
-        verify(defaultValidatedResponseAction).routeResponse(testCmId,jsonNode);
+        verify(defaultValidatedResponseAction).routeResponse(X_CM_ID, testCmId,jsonNode);
     }
 
     @Test

--- a/src/test/java/in/projecteka/gateway/consent/ConsentControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/consent/ConsentControllerTest.java
@@ -92,7 +92,7 @@ class ConsentControllerTest {
 
         String testId = "testId";
         when(consentRequestValidator.validateResponse(requestEntity, X_HIU_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
-        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
+        when(validatedResponseAction.execute(eq(X_HIU_ID), eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/consent/ConsentControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/consent/ConsentControllerTest.java
@@ -1,27 +1,39 @@
 package in.projecteka.gateway.consent;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nimbusds.jose.jwk.JWKSet;
 import in.projecteka.gateway.clients.ConsentFetchServiceClient;
 import in.projecteka.gateway.clients.ConsentRequestServiceClient;
 import in.projecteka.gateway.common.RequestOrchestrator;
 import in.projecteka.gateway.common.ResponseOrchestrator;
+import in.projecteka.gateway.common.ValidatedResponse;
+import in.projecteka.gateway.common.ValidatedResponseAction;
+import in.projecteka.gateway.common.Validator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static in.projecteka.gateway.common.Constants.X_HIU_ID;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -42,6 +54,16 @@ class ConsentControllerTest {
     @MockBean(name = "centralRegistryJWKSet")
     private JWKSet centralRegistryJWKSet;
 
+    @MockBean
+    Validator consentRequestValidator;
+
+    @MockBean
+    @Qualifier("consentResponseAction")
+    ValidatedResponseAction validatedResponseAction;
+
+    private @Captor
+    ArgumentCaptor<JsonNode> jsonNodeArgumentCaptor;
+
     @Test
     void shouldFireAndForgetForConsentRequestInit() {
         Mockito.when(requestOrchestrator.processRequest(Mockito.any(), eq(X_CM_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
@@ -57,8 +79,20 @@ class ConsentControllerTest {
     }
 
     @Test
-    void shouldFireAndForgetForConsentRequestOnInit() {
-        Mockito.when(consentResponseOrchestrator.processResponse(Mockito.any(), eq(X_HIU_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
+    void shouldFireAndForgetForConsentRequestOnInit() throws JsonProcessingException {
+
+        String requestId = UUID.randomUUID().toString();
+        String callerRequestId = UUID.randomUUID().toString();
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("requestId",requestId);
+        ObjectNode respNode = new ObjectMapper().createObjectNode();
+        respNode.put("requestId",callerRequestId);
+        objectNode.set("resp",respNode);
+        HttpEntity<String> requestEntity = new HttpEntity<>(new ObjectMapper().writeValueAsString(objectNode));
+
+        String testId = "testId";
+        when(consentRequestValidator.validateResponse(requestEntity, X_HIU_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
+        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
@@ -15,11 +15,12 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.time.Duration;
 
 import static in.projecteka.gateway.common.Constants.X_HIP_ID;
-import static org.mockito.ArgumentMatchers.eq;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -53,7 +54,7 @@ class DiscoveryControllerTest {
 
     @Test
     public void shouldFireAndForgetForOnDiscover() {
-        Mockito.when(discoveryResponseOrchestrator.processResponse(Mockito.any())).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
+        Mockito.when(discoveryResponseOrchestrator.processResponse(Mockito.any(), eq(X_CM_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
@@ -87,7 +87,7 @@ class DiscoveryControllerTest {
 
         String testId = "testId";
         when(discoveryValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
-        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
+        when(validatedResponseAction.execute(eq(X_CM_ID), eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/discovery/DiscoveryControllerTest.java
@@ -1,16 +1,26 @@
 package in.projecteka.gateway.link.discovery;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nimbusds.jose.jwk.JWKSet;
 import in.projecteka.gateway.clients.DiscoveryServiceClient;
 import in.projecteka.gateway.common.RequestOrchestrator;
 import in.projecteka.gateway.common.ResponseOrchestrator;
+import in.projecteka.gateway.common.ValidatedResponse;
+import in.projecteka.gateway.common.ValidatedResponseAction;
+import in.projecteka.gateway.common.Validator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -19,8 +29,10 @@ import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import static in.projecteka.gateway.common.Constants.X_HIP_ID;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -38,6 +50,16 @@ class DiscoveryControllerTest {
     @MockBean(name = "centralRegistryJWKSet")
     private JWKSet centralRegistryJWKSet;
 
+    @MockBean
+    Validator discoveryValidator;
+
+    @MockBean
+    @Qualifier("discoveryResponseAction")
+    ValidatedResponseAction validatedResponseAction;
+
+    private @Captor
+    ArgumentCaptor<JsonNode> jsonNodeArgumentCaptor;
+
     @Test
     public void shouldFireAndForgetForDiscover() {
         Mockito.when(requestOrchestrator.processRequest(Mockito.any(), eq(X_HIP_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
@@ -53,8 +75,19 @@ class DiscoveryControllerTest {
     }
 
     @Test
-    public void shouldFireAndForgetForOnDiscover() {
-        Mockito.when(discoveryResponseOrchestrator.processResponse(Mockito.any(), eq(X_CM_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
+    public void shouldFireAndForgetForOnDiscover() throws JsonProcessingException {
+        String requestId = UUID.randomUUID().toString();
+        String callerRequestId = UUID.randomUUID().toString();
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("requestId",requestId);
+        ObjectNode respNode = new ObjectMapper().createObjectNode();
+        respNode.put("requestId",callerRequestId);
+        objectNode.set("resp",respNode);
+        HttpEntity<String> requestEntity = new HttpEntity<>(new ObjectMapper().writeValueAsString(objectNode));
+
+        String testId = "testId";
+        when(discoveryValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
+        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
@@ -16,6 +16,8 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import reactor.core.publisher.Mono;
+import static in.projecteka.gateway.common.Constants.X_CM_ID;
+import static org.mockito.ArgumentMatchers.eq;
 
 import java.time.Duration;
 
@@ -56,7 +58,7 @@ public class LinkControllerTest {
 
     @Test
     public void shouldFireAndForgetForLinkOnInit() {
-        Mockito.when(linkInitResponseOrchestrator.processResponse(Mockito.any())).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
+        Mockito.when(linkInitResponseOrchestrator.processResponse(Mockito.any(), eq(X_CM_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
@@ -1,17 +1,27 @@
 package in.projecteka.gateway.link.link;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.nimbusds.jose.jwk.JWKSet;
 import in.projecteka.gateway.clients.LinkConfirmServiceClient;
 import in.projecteka.gateway.clients.LinkInitServiceClient;
 import in.projecteka.gateway.common.RequestOrchestrator;
 import in.projecteka.gateway.common.ResponseOrchestrator;
+import in.projecteka.gateway.common.ValidatedResponse;
+import in.projecteka.gateway.common.ValidatedResponseAction;
+import in.projecteka.gateway.common.Validator;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Captor;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpEntity;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.reactive.server.WebTestClient;
@@ -20,9 +30,10 @@ import static in.projecteka.gateway.common.Constants.X_CM_ID;
 import static org.mockito.ArgumentMatchers.eq;
 
 import java.time.Duration;
+import java.util.UUID;
 
 import static in.projecteka.gateway.common.Constants.X_HIP_ID;
-import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
 
 @ExtendWith(SpringExtension.class)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -42,6 +53,16 @@ public class LinkControllerTest {
     @MockBean(name = "centralRegistryJWKSet")
     private JWKSet centralRegistryJWKSet;
 
+    @MockBean
+    Validator linkValidator;
+
+    @MockBean
+    @Qualifier("linkInitResponseAction")
+    ValidatedResponseAction validatedResponseAction;
+
+    private @Captor
+    ArgumentCaptor<JsonNode> jsonNodeArgumentCaptor;
+
     @Test
     public void shouldFireAndForgetForLinkInit() {
         Mockito.when(linkInitRequestOrchestrator.processRequest(Mockito.any(), eq(X_HIP_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
@@ -57,8 +78,19 @@ public class LinkControllerTest {
     }
 
     @Test
-    public void shouldFireAndForgetForLinkOnInit() {
-        Mockito.when(linkInitResponseOrchestrator.processResponse(Mockito.any(), eq(X_CM_ID))).thenReturn(Mono.delay(Duration.ofSeconds(10)).then());
+    public void shouldFireAndForgetForLinkOnInit() throws JsonProcessingException {
+        String requestId = UUID.randomUUID().toString();
+        String callerRequestId = UUID.randomUUID().toString();
+        ObjectNode objectNode = new ObjectMapper().createObjectNode();
+        objectNode.put("requestId",requestId);
+        ObjectNode respNode = new ObjectMapper().createObjectNode();
+        respNode.put("requestId",callerRequestId);
+        objectNode.set("resp",respNode);
+        HttpEntity<String> requestEntity = new HttpEntity<>(new ObjectMapper().writeValueAsString(objectNode));
+
+        String testId = "testId";
+        when(linkValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
+        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient

--- a/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
+++ b/src/test/java/in/projecteka/gateway/link/link/LinkControllerTest.java
@@ -90,7 +90,7 @@ public class LinkControllerTest {
 
         String testId = "testId";
         when(linkValidator.validateResponse(requestEntity, X_CM_ID)).thenReturn(Mono.just(new ValidatedResponse(testId, callerRequestId, objectNode)));
-        when(validatedResponseAction.execute(eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
+        when(validatedResponseAction.execute(eq(X_CM_ID), eq(testId), jsonNodeArgumentCaptor.capture())).thenReturn(Mono.empty());
 
         WebTestClient mutatedWebTestClient = webTestClient.mutate().responseTimeout(Duration.ofSeconds(5)).build();
         mutatedWebTestClient


### PR DESCRIPTION
* Refactors the response validator to accept CM_ID/HIU_ID and validate the response.